### PR TITLE
Implement farm caching

### DIFF
--- a/client/ayon_royalrender/lib.py
+++ b/client/ayon_royalrender/lib.py
@@ -3,6 +3,8 @@
 import os
 import re
 from datetime import datetime
+from enum import Enum
+from typing import Optional, Any, Dict
 
 import pyblish.api
 
@@ -154,7 +156,13 @@ class BaseCreateRoyalRenderJob(
             instance.data["rrJobs"] = []
 
     def get_job(
-        self, instance, script_path, render_path, node_name, single=False
+        self,
+        instance,
+        script_path,
+        render_path,
+        node_name,
+        single=False,
+        job_type="RENDER"
     ):
         """Get RR job based on current instance.
 
@@ -201,22 +209,9 @@ class BaseCreateRoyalRenderJob(
         )
         instance.data["expectedFiles"].extend(expected_files)
 
-        # anatomy_data = instance.context.data["anatomyData"]
-        environment = RREnvList(
-            {
-                "AYON_PROJECT_NAME": instance.context.data["projectName"],
-                "AYON_FOLDER_PATH": instance.context.data["folderPath"],
-                "AYON_TASK_NAME": instance.context.data["task"],
-                "AYON_USERNAME": instance.context.data["user"],
-                "AYON_APP_NAME": os.environ["AYON_APP_NAME"],
-                "AYON_RENDER_JOB": "1",
-                "AYON_BUNDLE_NAME": os.environ["AYON_BUNDLE_NAME"],
-                # these are optional, but required on render nodes
-                "AYON_EXECUTABLE": os.environ.get("AYON_EXECUTABLE"),
-                "AYON_SERVER_URL": os.environ.get("AYON_SERVER_URL"),
-                "AYON_API_KEY": os.environ.get("AYON_API_KEY"),
-            }
-        )
+        environment = get_instance_job_envs(instance)
+        environment.update(JobType[job_type].get_job_env())
+        environment = RREnvList(**environment)
 
         render_dir = render_dir.replace("\\", "/")
         job = RRJob(
@@ -240,8 +235,8 @@ class BaseCreateRoyalRenderJob(
             SceneDatabaseDir=script_path,
             CustomSHotName=jobname,
             CompanyProjectName=instance.context.data["projectName"],
-            ImageWidth=instance.data["resolutionWidth"],
-            ImageHeight=instance.data["resolutionHeight"],
+            ImageWidth=instance.data.get("resolutionWidth"),
+            ImageHeight=instance.data.get("resolutionHeight"),
             CustomAttributes=custom_attributes,
             SubmitterParameters=submitter_parameters_job,
             rrEnvList=environment.serialize(),
@@ -326,3 +321,51 @@ class BaseCreateRoyalRenderJob(
             path = path.replace(str(first_frame).zfill(padding), "#" * padding)
 
         return path
+
+
+def get_instance_job_envs(instance) -> "dict[str, str]":
+    """Add all job environments as specified on the instance and context.
+
+    Any instance `job_env` vars will override the context `job_env` vars.
+    """
+    # Avoid import from 'ayon_core.pipeline'
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
+    env = {}
+    for job_env in [
+        instance.context.data.get(FARM_JOB_ENV_DATA_KEY, {}),
+        instance.data.get(FARM_JOB_ENV_DATA_KEY, {})
+    ]:
+        if job_env:
+            env.update(job_env)
+
+    # Return the dict sorted just for readability in future logs
+    if env:
+        env = dict(sorted(env.items()))
+
+    return env
+
+
+class JobType(str, Enum):
+    UNDEFINED = "undefined"
+    RENDER = "render"
+    PUBLISH = "publish"
+    REMOTE = "remote"
+
+    def get_job_env(self) -> Dict[str, str]:
+        return {
+            "AYON_PUBLISH_JOB": str(int(self == JobType.PUBLISH)),
+            "AYON_RENDER_JOB": str(int(self == JobType.RENDER)),
+            "AYON_REMOTE_PUBLISH": str(int(self == JobType.REMOTE)),
+        }
+
+    @classmethod
+    def get(
+        cls, value: Any, default: Optional[Any] = None
+    ) -> "JobType":
+        try:
+            return cls(value)
+        except ValueError:
+            if default is None:
+                return cls.UNDEFINED
+            return default

--- a/client/ayon_royalrender/plugins/publish/collect_royalrender_job_nev_vars.py
+++ b/client/ayon_royalrender/plugins/publish/collect_royalrender_job_nev_vars.py
@@ -1,0 +1,44 @@
+import os
+
+import pyblish.api
+
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
+
+class CollectRoyalRenderJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with RR jobs"""
+    order = pyblish.api.CollectorOrder
+    label = "RoyalRender Farm Environment Variables"
+    targets = ["local"]
+
+    ENV_KEYS = [
+        # applications addon
+        "AYON_APP_NAME",
+
+        # ftrack addon
+        "FTRACK_API_KEY",
+        "FTRACK_API_USER",
+        "FTRACK_SERVER",
+
+        # kitsu addon
+        "KITSU_SERVER",
+        "KITSU_LOGIN",
+        "KITSU_PWD",
+
+        # Shotgrid / Flow addon
+        "AYON_SG_USERNAME",
+
+        # Not sure how this is usefull for farm, scared to remove
+        "PYBLISHPLUGINPATH",
+    ]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        for key in self.ENV_KEYS:
+            # Skip already set keys
+            if key in env:
+                continue
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value

--- a/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
+++ b/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
@@ -23,7 +23,7 @@ class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder
     label = "Collect Royal Render path name from the Instance"
-    families = ["render", "prerender", "renderlayer"]
+    families = ["render", "prerender", "renderlayer", "pointcache"]
 
     def process(self, instance):
         instance.data["rr_root"] = self._collect_root(instance)

--- a/client/ayon_royalrender/plugins/publish/create_maya_cache_royalrender_job.py
+++ b/client/ayon_royalrender/plugins/publish/create_maya_cache_royalrender_job.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Submitting render job to RoyalRender."""
+import os
+
+from maya import cmds
+from maya.OpenMaya import MGlobal  # noqa: F401
+
+from ayon_core.pipeline.farm.tools import iter_expected_files
+
+from ayon_royalrender import lib
+from ayon_royalrender.scripts import remote_publish
+
+
+class CreateMayaCacheRoyalRenderJob(lib.BaseCreateRoyalRenderJob):
+    label = "Create Maya Cache job in RR"
+    hosts = ["maya"]
+    families = ["pointcache"]
+
+    def update_job_with_host_specific(self, instance, job):
+        job.Software = "Maya"
+        job.Renderer = "RemotePublish"
+        job.Version = "{0:.2f}".format(MGlobal.apiVersion() / 10000)
+        job.CustomScriptFile = remote_publish.__file__.replace(".pyc", ".py")
+        workspace = instance.context.data["workspaceDir"]
+        job.SceneDatabaseDir = workspace
+        job.rrEnvList += f"~~~INSTANCE_IDS={instance.name}"
+
+        return job
+
+    def process(self, instance):
+        """Plugin entry point."""
+        super(CreateMayaCacheRoyalRenderJob, self).process(instance)
+
+        if not instance.data.get("farm"):
+                self.log.info("Skipping local instance.")
+                return
+
+        # append full path
+        renders_dir = os.path.join(
+           cmds.workspace(query=True, rootDirectory=True),
+           cmds.workspace(fileRuleEntry="images")
+        )
+
+        job = self.get_job(
+            instance,
+            self.scene_path,
+            renders_dir,
+            "",
+            job_type="REMOTE"
+        )
+        job = self.update_job_with_host_specific(instance, job)
+
+        instance.data["rrJobs"].append(job)

--- a/client/ayon_royalrender/rr_job.py
+++ b/client/ayon_royalrender/rr_job.py
@@ -177,6 +177,8 @@ class RRJob(object):
     rrEnvList = attr.ib(default=None, type=str)  # type: str
     rrEnvFile = attr.ib(default=None, type=str)  # type: str
 
+    CustomScriptFile = attr.ib(default=None)  # type: str
+
 
 class SubmitterParameter:
     """Wrapper for Submitter Parameters."""

--- a/client/ayon_royalrender/rr_root/render_apps/_config_inhouse/E02__AYON_RemotePublish__global__inhouse.cfg
+++ b/client/ayon_royalrender/rr_root/render_apps/_config_inhouse/E02__AYON_RemotePublish__global__inhouse.cfg
@@ -1,0 +1,61 @@
+# config file format version 8.0
+#
+# Author: Ynput, Petr Kalis
+#
+# Last change: v9.1.07
+#
+# This render config executes a PYTHON script for remote publishing (now mostly pointcaches from
+# Maya) in AYON
+#
+# Process requires:
+# - extract environments controlled by AYON (same as for render jobs)
+# - apply them on environment where `mayapy` runs `remote_publish.py` script
+# - this script:
+# -- opens Maya scene
+# -- runs headless Publish
+#
+# TODO
+# - change `Name` if other DCCs will be implemented
+#
+################################## Identify Render Application ##################################
+Name= Maya
+rendererName= RemotePublish
+RendererLicense=
+Version=2009
+
+TYPEv9=AppScript
+
+TYPEv9=Execute
+ExecuteJobType=Once
+
+
+##################################  [Windows] [Linux] [OSX]  ##################################
+
+CommandLine= 	"<rrBin64>rrKillWait" 1 senddmp
+
+CommandLine= <rrEnvLine>
+
+CommandLine= <SetEnvGlobal>
+
+CommandLine= <SetEnvSoft>
+
+CommandLine=  <OsxApp "<rrBin64>rrPythonconsole" > "<RR_DIR>render_apps/_prepost_scripts/ayon_inject_envvar.py"  -jid <JID>
+
+CommandLine= <envFileExecute <rrEnvFile>>
+
+CommandLine= <rrEnvLine>
+
+CommandLine= "<rrBin64>rrKillWait" 1 senddmp
+
+CommandLine= <ResetExitCode>
+
+CommandLine=
+    ::win "<Exe><ED>mayapy.exe"
+    ::lx  "<Exe><ED>maypy"
+    ::osx "<Exe><ED>maypy"
+	"<PD/<CustomScriptFile>"
+	-scene "<PD/<Scene>>"
+	-rrfile "<PD/<rrEnvFile>>"
+
+CommandLine=
+	<CheckExitCode> <FN>

--- a/client/ayon_royalrender/rr_root/render_apps/_config_inhouse/E02__AYON_RemotePublish__global__inhouse.cfg
+++ b/client/ayon_royalrender/rr_root/render_apps/_config_inhouse/E02__AYON_RemotePublish__global__inhouse.cfg
@@ -55,7 +55,6 @@ CommandLine=
     ::osx "<Exe><ED>maypy"
 	"<PD/<CustomScriptFile>"
 	-scene "<PD/<Scene>>"
-	-rrfile "<PD/<rrEnvFile>>"
 
 CommandLine=
 	<CheckExitCode> <FN>

--- a/client/ayon_royalrender/rr_root/render_apps/_prepost_scripts/ayon_inject_envvar.py
+++ b/client/ayon_royalrender/rr_root/render_apps/_prepost_scripts/ayon_inject_envvar.py
@@ -68,8 +68,9 @@ class InjectEnvironment:
         self.meta_dir = meta_dir
         envs = self._get_job_environments()
 
-        if not envs.get("AYON_RENDER_JOB"):
-            logs.append("Not a ayon render job, skipping.")
+        if (not envs.get("AYON_RENDER_JOB") and
+                not envs.get("AYON_REMOTE_PUBLISH")):
+            logs.append("Not a ayon render or remote publish job, skipping.")
             return
 
         if not self._is_required_environment():

--- a/client/ayon_royalrender/scripts/remote_publish.py
+++ b/client/ayon_royalrender/scripts/remote_publish.py
@@ -14,7 +14,7 @@ from ayon_core.pipeline.create import CreateContext
 from ayon_core.pipeline import registered_host
 
 
-def remote_publish(scene_path, rrfile_path):
+def remote_publish(scene_path):
     log = Logger.get_logger(__name__)
 
     error_format = "Failed {{plugin.__name__}}: {{error}}:{{error.traceback}}"
@@ -49,10 +49,8 @@ if __name__ == "__main__":
     # Perform remote publish with thorough error checking
     parser = argparse.ArgumentParser(description='Process Maya scene file')
     parser.add_argument('-scene', required=True, help='Path to Maya scene file')
-    parser.add_argument('-rrfile', required=True, help='Path to extracted environments')
 
     args = parser.parse_args()
     scene_path = args.scene
-    rrfile_path = args.rrfile
 
-    remote_publish(scene_path, rrfile_path)
+    remote_publish(scene_path)

--- a/client/ayon_royalrender/scripts/remote_publish.py
+++ b/client/ayon_royalrender/scripts/remote_publish.py
@@ -1,0 +1,58 @@
+import os
+import argparse
+
+import pyblish.api
+import pyblish.util
+
+import maya.standalone
+
+maya.standalone.initialize(name="python")
+from maya import cmds
+
+from ayon_core.lib import Logger
+from ayon_core.pipeline.create import CreateContext
+from ayon_core.pipeline import registered_host
+
+
+def remote_publish(scene_path, rrfile_path):
+    log = Logger.get_logger(__name__)
+
+    error_format = "Failed {{plugin.__name__}}: {{error}}:{{error.traceback}}"
+
+    cmds.file(scene_path, open=True)
+
+    host = registered_host()
+    create_context = CreateContext(host)
+    pyblish_context = pyblish.api.Context()
+    solo_instance_ids: set[str] = set(
+        os.environ.get("INSTANCE_IDS", "").split(";")
+    )
+
+    for instance in create_context.instances:
+        active: bool = instance.id in solo_instance_ids
+        log.info(f"Setting active state {active} for instance: {instance}")
+        instance["active"] = active
+
+        pyblish_context.data["create_context"] = create_context
+
+    for result in pyblish.util.publish_iter(
+        context=pyblish_context,
+        plugins=create_context.publish_plugins
+
+    ):
+        if result["error"]:
+            error_message = error_format.format(**result)
+            log.error(error_message)
+            raise RuntimeError("Fatal Error : {}".format(error_message))
+
+if __name__ == "__main__":
+    # Perform remote publish with thorough error checking
+    parser = argparse.ArgumentParser(description='Process Maya scene file')
+    parser.add_argument('-scene', required=True, help='Path to Maya scene file')
+    parser.add_argument('-rrfile', required=True, help='Path to extracted environments')
+
+    args = parser.parse_args()
+    scene_path = args.scene
+    rrfile_path = args.rrfile
+
+    remote_publish(scene_path, rrfile_path)


### PR DESCRIPTION
## Changelog Description
Extracting and publishing of pointcaches (for example) is slow and should be offloaded to the farm if possible.

## Additional review information
Extraction and publish directly from Maya on RoyalRender server is handled by:
- specific Render config is triggered `inhouse/E02__AYON_RemotePublish__global__inhouse.cfg `
-- this config tries to extract and inject environment variables via existing `Pre-` script `Ayon_ayon_inject_envvar.cfg` (couldn't figure out how to trigger it without triggering it directly in `RemotePublish` config)
-- this should extract AYON controlled environments into `rrEnv` file (which location is hooked to the job and it is working with rendering jobs)
-- after env vars are set, `mayapy` triggers `remote_publish.py` script which opens provided scene and runs Publish process

Current issues:
- `CommandLine=  <OsxApp "<rrBin64>rrPythonconsole" >` seems to be not blocking or `CommandLine= <envFileExecute <rrEnvFile>>` cannot find extracted file on the first go around
<img width="722" height="139" alt="image" src="https://github.com/user-attachments/assets/ba2727a1-079a-4a96-ae47-11bf4efcc4e9" />
vs
<img width="756" height="122" alt="image" src="https://github.com/user-attachments/assets/d1e6caed-fb8a-42a2-bdd2-65315a944097" />
(Please notice different env var at line 180)

(Another issue that context doesn't seem to be filled properly
```
     folder_path = folder_entity["path"] 
R107|                   ~~~~~~~~~~~~~^^^^^^^^ 
R108| TypeError: 'NoneType' object is not subscriptable 
```
Not sure if RR is not propagating env vars properly or AYON issue.)

## Testing notes:
1. start with this step
2. follow this step
