### PR TITLE
Adjust default AYON install paths.

### DIFF
--- a/client/ayon_royalrender/rr_root/render_apps/_install_paths/Ayon.cfg
+++ b/client/ayon_royalrender/rr_root/render_apps/_install_paths/Ayon.cfg
@@ -1,6 +1,6 @@
 [Windows]
 Executable= ayon_console.exe
-Path= OS; <ProgramFiles(x86)>\Ynput\AYON*\ayon_console.exe
+Path= OS; <ProgramFiles>\Ynput\AYON*\ayon_console.exe
 Path= 32; <ProgramFiles(x86)>\Ynput\AYON*\ayon_console.exe
 
 [Linux]
@@ -8,5 +8,5 @@ Executable= ayon_console
 Path= OS; /opt/ayon-launcher/*/ayon_console
 
 [Mac]
-Executable= ayon_console
-Path= OS; /Applications/Ayon*/Content/MacOS/ayon_console
+Executable= ayon
+Path= OS; /Applications/Ayon*/Contents/MacOS/ayon


### PR DESCRIPTION
## Changelog Description

Recently re-installed my RoyalRender locally on Windows and Mac.
Figured out our default install paths are wrong.

## Testing notes:
1. Works for me with these changes
