### PR TITLE
Fix rrRoot detection on macOs.

### DIFF
--- a/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
+++ b/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
@@ -6,9 +6,9 @@ Provides:
     instance.data["rr_root"] (str) - root folder of RoyalRender server
 """
 import os.path
+import platform
 
 import pyblish.api
-from ayon_royalrender.rr_job import get_rr_platform
 
 
 class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
@@ -40,15 +40,8 @@ class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
         rr_paths = rr_settings["rr_paths"]
         selected_keys = rr_settings["selected_rr_paths"]
 
-        platform = get_rr_platform()
-
-        # RoyalRender uses "osx" as platform name on macOS
-        # while AYON MultiplatformPathModel uses "darwin"
-        if platform == "osx":
-            platform = "darwin"
-
         key_to_path = {
-            item["name"]: item["value"][platform]
+            item["name"]: item["value"][platform.system().lower()]
             for item in rr_paths
         }
 

--- a/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
+++ b/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
@@ -41,6 +41,12 @@ class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
         selected_keys = rr_settings["selected_rr_paths"]
 
         platform = get_rr_platform()
+
+        # RoyalRender uses "osx" as platform name on macOS
+        # while AYON MultiplatformPathModel uses "darwin"
+        if platform == "osx":
+            platform = "darwin"
+
         key_to_path = {
             item["name"]: item["value"][platform]
             for item in rr_paths

--- a/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
+++ b/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
@@ -40,8 +40,9 @@ class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
         rr_paths = rr_settings["rr_paths"]
         selected_keys = rr_settings["selected_rr_paths"]
 
+        platform_key  = platform.system().lower()
         key_to_path = {
-            item["name"]: item["value"][platform.system().lower()]
+            item["name"]: item["value"][platform_key ]
             for item in rr_paths
         }
 

--- a/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
+++ b/client/ayon_royalrender/plugins/publish/collect_rr_path_from_instance.py
@@ -42,7 +42,7 @@ class CollectRRPathFromInstance(pyblish.api.InstancePlugin):
 
         platform_key  = platform.system().lower()
         key_to_path = {
-            item["name"]: item["value"][platform_key ]
+            item["name"]: item["value"][platform_key]
             for item in rr_paths
         }
 


### PR DESCRIPTION
## Changelog Description

Fix small mismatch between RR "osx" and AYON "darwin" platform name for macOS.

## Testing notes:
1. Able to dispatch RR jobs from macOs with this change. `KeyError` otherwise.
